### PR TITLE
Add login redirect

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -119,14 +119,10 @@ if ( is_admin() ) {
 }
 
 // Required files
-require CRAZYDOMAINS_PLUGIN_DIR . '/inc/Admin.php';
-require CRAZYDOMAINS_PLUGIN_DIR . '/inc/AdminBar.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/base.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/jetpack.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/partners.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/performance.php';
-require CRAZYDOMAINS_PLUGIN_DIR . '/inc/RestApi/CachingController.php';
-require CRAZYDOMAINS_PLUGIN_DIR . '/inc/RestApi/SettingsController.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/RestApi/rest-api.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/settings.php';
 require CRAZYDOMAINS_PLUGIN_DIR . '/inc/updates.php';

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -137,3 +137,4 @@ if ( is_admin() ) {
 }
 
 AdminBar::init();
+LoginRedirect::init();

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
             "homepage": "https://evanmullins.com"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "CrazyDomains\\": "inc/"
+        }
+    },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true,
@@ -34,11 +39,6 @@
                 "newfold-labs/*"
             ]
         }
-    },
-    "require-dev": {
-        "newfold-labs/wp-php-standards": "^1.2",
-        "wp-cli/i18n-command": "^2.2",
-        "wp-phpunit/wp-phpunit": "^6.2"
     },
     "scripts": {
         "fix": "vendor/bin/phpcbf --standard=phpcs.xml .",
@@ -67,5 +67,10 @@
         "newfold-labs/wp-module-sso": "^1.0.3",
         "wp-forge/wp-update-handler": "^1.0",
         "wp-forge/wp-upgrade-handler": "^1.0"
+    },
+    "require-dev": {
+        "newfold-labs/wp-php-standards": "^1.2",
+        "wp-cli/i18n-command": "^2.2",
+        "wp-phpunit/wp-phpunit": "^6.2"
     }
 }

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -22,7 +22,7 @@ class LoginRedirect {
 	/**
 	 * Get default redirect URL.
 	 *
-	 * @param string $url
+	 * @param string $url The redirect URL
 	 *
 	 * @return string
 	 */

--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace CrazyDomains;
+
+/**
+ * Class LoginRedirect
+ *
+ * @package CrazyDomains
+ */
+class LoginRedirect {
+
+	/**
+	 * Initialize the login redirect functionality.
+	 */
+	public static function init() {
+		add_action( 'login_redirect', array( __CLASS__, 'on_login_redirect' ), 10, 3 );
+		add_action( 'login_init', array( __CLASS__, 'on_login_init' ), 10, 3 );
+		add_filter( 'login_form_defaults', array( __CLASS__, 'filter_login_form_defaults' ) );
+		add_filter( 'newfold_sso_success_url_default', array( __CLASS__, 'get_default_redirect_url' ) );
+	}
+
+	/**
+	 * Get default redirect URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public static function get_default_redirect_url( $url ) {
+		return current_user_can( 'manage_options' ) ? self::get_crazydomains_dashboard_url() : $url;
+	}
+
+	/**
+	 * Set the $_REQUEST['redirect_to'] value on the login_init action since there isn't a better way to do it before
+	 * WordPress automatically defaults it to the WordPress dashboard URL.
+	 */
+	public static function on_login_init() {
+		if ( ! isset( $_REQUEST['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_REQUEST['redirect_to'] = self::get_crazydomains_dashboard_url();
+		}
+	}
+
+	/**
+	 * Set default redirect used in the wp_login_form() function.
+	 *
+	 * @param array $defaults Collection of existing defaults.
+	 *
+	 * @return array
+	 */
+	public static function filter_login_form_defaults( array $defaults ) {
+		$defaults['redirect'] = self::get_crazydomains_dashboard_url();
+
+		return $defaults;
+	}
+
+	/**
+	 * Customize the login redirect URL if one hasn't already been set.
+	 *
+	 * @param string   $redirect_to           Current redirect URL.
+	 * @param string   $requested_redirect_to Requested redirect URL.
+	 * @param \WP_User $user                  WordPress user.
+	 *
+	 * @return string
+	 */
+	public static function on_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
+
+		if ( self::is_user( $user ) ) {
+			// If no redirect is defined and the user is an administrator, redirect to the Crazy Domains dashboard.
+			if ( empty( $requested_redirect_to ) && self::is_administrator( $user ) ) {
+				return self::get_crazydomains_dashboard_url();
+			}
+
+			// If the user isn't an admin and the redirect is to the Crazy Domains dashboard, point them to the WP dashboard instead.
+			if ( ! self::is_administrator( $user ) && self::is_crazydomains_redirect( $requested_redirect_to ) ) {
+				return admin_url( '/' );
+			}
+		}
+
+		return $redirect_to;
+	}
+
+	/**
+	 * Check if we have a valid user.
+	 *
+	 * @param \WP_User $user The WordPress user object.
+	 *
+	 * @return bool
+	 */
+	public static function is_user( $user ) {
+		return $user && is_object( $user ) && is_a( $user, 'WP_User' );
+	}
+
+	/**
+	 * Check if a user is an administrator.
+	 *
+	 * @param \WP_User $user WordPress user.
+	 *
+	 * @return bool
+	 */
+	public static function is_administrator( $user ) {
+		return self::is_user( $user ) && $user->has_cap( 'manage_options' );
+	}
+
+	/**
+	 * Check if the current redirect is to the Crazy Domains plugin.
+	 *
+	 * @param string $redirect The current redirect URL.
+	 *
+	 * @return bool
+	 */
+	public static function is_crazydomains_redirect( $redirect ) {
+		return false !== strpos( $redirect, admin_url( 'admin.php?page=crazy-domains' ) );
+	}
+
+	/**
+	 * Get the Crazy Domains dashboard URL.
+	 *
+	 * @return string
+	 */
+	public static function get_crazydomains_dashboard_url() {
+		return admin_url( 'admin.php?page=crazy-domains#/home' );
+	}
+
+}

--- a/inc/RestApi/rest-api.php
+++ b/inc/RestApi/rest-api.php
@@ -13,8 +13,8 @@ namespace CrazyDomains;
 function init_rest_api() {
 
 	$controllers = array(
-		'CrazyDomains\\RestApi\\CachingController',
-		'CrazyDomains\\RestApi\\SettingsController',
+		__NAMESPACE__ . '\\RestApi\\CachingController',
+		__NAMESPACE__ . '\\RestApi\\SettingsController',
 	);
 
 	foreach ( $controllers as $controller ) {


### PR DESCRIPTION
Add a login redirect to take users to the CrazyDomains dashboard instead of the default WordPress dashboard.

Resolves #22 