### PR TITLE
Update About URL for crazydomains.com

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -183,7 +183,7 @@ final class Admin {
 	 * @return string
 	 */
 	public static function add_brand_to_admin_footer( $footer_text ) {
-		$footer_text = \sprintf( \__( 'Thank you for creating with <a href="https://wordpress.org/">WordPress</a> and <a href="https://crazydomains.com/about-us">Crazy Domains</a>.', 'wp-plugin-crazy-domains' ) );
+		$footer_text = \sprintf( \__( 'Thank you for creating with <a href="https://wordpress.org/">WordPress</a> and <a href="https://crazydomains.com/about">Crazy Domains</a>.', 'wp-plugin-crazy-domains' ) );
 		return $footer_text;
 	}
 } // END \CrazyDomains\Admin

--- a/languages/wp-plugin-crazy-domains.pot
+++ b/languages/wp-plugin-crazy-domains.pot
@@ -122,7 +122,7 @@ msgid "Please update now"
 msgstr ""
 
 #: inc/Admin.php:187
-msgid "Thank you for creating with <a href=\"https://wordpress.org/\">WordPress</a> and <a href=\"https://crazydomains.com/about-us\">Crazy Domains</a>."
+msgid "Thank you for creating with <a href=\"https://wordpress.org/\">WordPress</a> and <a href=\"https://crazydomains.com/about\">Crazy Domains</a>."
 msgstr ""
 
 #: inc/AdminBar.php:35


### PR DESCRIPTION
Appears crazydomains.com/about-us is returning a 404 now. Updated to crazydomains.com/about.