### PR TITLE
validate that wp versions match in release workflow

### DIFF
--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -102,6 +102,15 @@ jobs:
       - name: NPM Install
         run: npm install --legacy-peer-deps
 
+      - name: Validate WP Versions
+        if: ${{ (github.repository == 'newfold-labs/wp-plugin-crazy-domains') && (github.event.release.prerelease == false) }}
+        run: |
+          wpEnvVersion=`grep "WordPress/WordPress#tags/" .wp-env.json | grep -Eo "[0-9\.]*"`
+          pluginHeaderTestedVersion=`grep "Tested up to:" wp-plugin-crazy-domains.php | grep -Eo "[0-9\.]*"`
+          echo "wp-env version: $wpEnvVersion"
+          echo "Plugin header tested version: $pluginHeaderTestedVersion"
+          [[ "$wpEnvVersion" == "$pluginHeaderTestedVersion" ]] || exit 1
+
       - name: Build JavaScript
         run: npm run build
 


### PR DESCRIPTION
In the release workflow, we're adding a job to check the wp version against the tested version the plugin reports.

We want this to always be the latest version so users have confidence in updates.

This addresses [PRESS1-192](https://jira.newfold.com/browse/PRESS1-192)