### PR TITLE
Add tests for onboarding

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -44,13 +44,22 @@ module.exports = defineConfig({
                 }
             }
 
-            if (config.env.phpVersion) {
-                if (config.env.phpVersion.split('.').length !== 3) {
-                    config.env.phpSemverVersion = `${config.env.phpVersion}.0`;
-                } else {
-                    config.env.phpSemverVersion = config.env.phpVersion;
-                }
-            }
+			// Ensure that we have a semantically correct PHP version number for comparisons.
+			if ( config.env.phpVersion ) {
+				if ( config.env.phpVersion.split( '.' ).length !== 3 ) {
+					config.env.phpSemverVersion = `${ config.env.phpVersion }.0`;
+				} else {
+					config.env.phpSemverVersion = config.env.phpVersion;
+				}
+			}
+			
+			// Exclude onboarding/ecommerce tests for PHP lower than 7.3 (7.1 and 7.2)
+			if ( semver.satisfies( config.env.phpSemverVersion, '<7.3.0' ) ) {
+				config.excludeSpecPattern = config.excludeSpecPattern.concat( [
+					'vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/3-ecommerce-onboarding-flow/**',
+					'vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/2-general-onboarding-flow/top-priority.cy.js',
+				] );
+			}
 
             on('task', {
                 log(message) {
@@ -73,8 +82,7 @@ module.exports = defineConfig({
             'vendor/newfold-labs/**/tests/cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
         ],
 		excludeSpecPattern: [
-            "vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/**",
-			"vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/wp-module-support/",
+            'vendor/newfold-labs/**/tests/cypress/integration/wp-module-support/*.cy.js', // skip any module's wp-module-support files
             "vendor/newfold-labs/wp-module-coming-soon/tests/cypress/integration/",
         ],
         supportFile: 'tests/cypress/support/index.js',

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -19,3 +19,7 @@ import './commands';
 before(() => {
 	cy.login(Cypress.env('wpUsername'), Cypress.env('wpPassword'));
 });
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+	return false
+});


### PR DESCRIPTION
This removes the onboarding module tests from the excluded spec pattern list.

It will allow onboarding cypress tests to run on this plugin.