### PR TITLE
Add yith-wonder theme dependency in wp-env

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -10,6 +10,9 @@
   "plugins": [
     "."
   ],
+  "themes": [
+    "https://downloads.wordpress.org/theme/yith-wonder.latest-stable.zip"
+  ],
   "port": 8884,
   "testsPort": 8885,
   "env": {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -53,11 +53,13 @@ module.exports = defineConfig({
                 }
             }
 
-			// Exclude ecommerce tests for WordPress lower than 6.4 (6.3 or 6.2) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
+            // Exclude ecommerce tests for WordPress lower than 6.4 (6.3 or 6.2) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
+            //  Since WooCommerce is unsupported, activation/deactivation/installation is going to fail
 			if ( semver.satisfies( config.env.wpSemverVersion, '<6.4.0' ) || semver.satisfies( config.env.phpSemverVersion, '<7.4.0' )) {
 				config.excludeSpecPattern = config.excludeSpecPattern.concat( [
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Site-Capabilities/**',
-					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/homePageWithWoo.cy.js',
+                    'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/homePageWithWoo.cy.js',
+                    'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Store/**'
 				] );
 			}
 


### PR DESCRIPTION
## Proposed changes

1. Currently onboarding color-step cypress test spec is failing to activate yith-wonder theme via cy.exec because the yith-wonder theme zip is not already installed on docker. 

Adding yith-wonder theme dependency in wp-env.json should fix the theme activation issue.

2. Skip ecommerce module store page tests for woo unsupported PHP and Wordpress versions

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
