### PR TITLE
Correct misbranded spelling of WonderBlocks and DOM ID dupe

### DIFF
--- a/languages/wp-plugin-crazy-domains.pot
+++ b/languages/wp-plugin-crazy-domains.pot
@@ -442,5 +442,5 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: build/2.1.0/index.js:1
-msgid "Wonder Blocks provides a library of customizable block patterns and page templates."
+msgid "WonderBlocks provides a library of customizable block patterns and page templates."
 msgstr ""

--- a/src/app/pages/settings/wonderBlocksSettings.js
+++ b/src/app/pages/settings/wonderBlocksSettings.js
@@ -18,17 +18,17 @@ const WonderBlocksSettings = () => {
 
 	const getWonderBlocksNoticeTitle = () => {
 		return wonderBlocks
-			? __( 'Wonder Blocks Enabled', 'wp-plugin-crazy-domains' )
-			: __( 'Wonder Blocks Disabled', 'wp-plugin-crazy-domains' );
+			? __( 'WonderBlocks Enabled', 'wp-plugin-crazy-domains' )
+			: __( 'WonderBlocks Disabled', 'wp-plugin-crazy-domains' );
 	};
 	const getWonderBlocksNoticeText = () => {
 		return wonderBlocks
 			? __(
-					'Create new content to see Wonder Blocks in action.',
+					'Create new content to see WonderBlocks in action.',
 					'wp-plugin-crazy-domains'
 			  )
 			: __(
-					'Wonder Blocks will no longer display.',
+					'WonderBlocks will no longer display.',
 					'wp-plugin-crazy-domains'
 			  );
 	};
@@ -77,10 +77,10 @@ const WonderBlocksSettings = () => {
 	return (
 		<div className="nfd-flex nfd-flex-col nfd-gap-6">
 			<ToggleField
-				id="help-center-toggle"
-				label="Wonder Blocks"
+				id="wonderblocks-toggle"
+				label="WonderBlocks"
 				description={ __(
-					'Wonder Blocks provides a library of customizable block patterns and page templates.',
+					'WonderBlocks provides a library of customizable block patterns and page templates.',
 					'wp-plugin-crazy-domains'
 				) }
 				disabled={ wonderBlocksLocked }


### PR DESCRIPTION
## Proposed changes

* WonderBlocks branding correction made in module weeks before feature toggle launched
* Copy-pasted ID fix to prevent ID duplication in DOM

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)