### PR TITLE
Adopt wp-php-standards 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "i18n-json": "Generate new language .json files."
     },
     "require-dev": {
-        "newfold-labs/wp-php-standards": "2.0.0",
+        "newfold-labs/wp-php-standards": "^2.0",
         "roave/security-advisories": "dev-latest",
         "wp-cli/i18n-command": "^2.6.5",
         "wp-phpunit/wp-phpunit": "^7.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b995d111b0ffe2fd05e2347fcb87d116",
+    "content-hash": "a1e13968bbdb946d6595a1bd31d77f8b",
     "packages": [
         {
             "name": "colinmollenhour/credis",


### PR DESCRIPTION
Updates the PHP standards dependency to ^2.0.